### PR TITLE
added extra check for payload post cram2bam

### DIFF
--- a/seq_tools/validation/c605_all_files_accessible.py
+++ b/seq_tools/validation/c605_all_files_accessible.py
@@ -58,6 +58,11 @@ class Checker(BaseChecker):
         files_unaccessbile_in_subdir = set()
 
         files_in_metadata = self.metadata['files']
+        
+        for f in files_in_metadata:
+            if f.get("info") and f["info"].get("original_cram_info"):
+                files_in_metadata.append(f['info']["original_cram_info"])
+
         for f in files_in_metadata:
             if f['fileName'] not in files_in_subdir:
                 files_missed_in_subdir.add(f['fileName'])

--- a/tests/expected_reports/anon_chr1_cram/anon_chr1_cram.missing.validation_report.INVALID.jsonl
+++ b/tests/expected_reports/anon_chr1_cram/anon_chr1_cram.missing.validation_report.INVALID.jsonl
@@ -1,0 +1,61 @@
+{
+  "tool": {
+    "name": "seq-tools",
+    "version": "1.2.2"
+  },
+  "metadata_file": "/Users/esu/Desktop/GitHub/seq-tools/tests/submissions/anon_chr1_cram/anon_chr1_cram.missing.json",
+  "data_dir": "/Users/esu/Desktop/GitHub/seq-tools/tests/submissions/anon_chr1_cram",
+  "started_at": "2022-10-18T18:40:41.601Z",
+  "ended_at": "2022-10-18T18:40:41.750Z",
+  "validation": {
+    "status": "INVALID",
+    "message": "Please see individual checks for details",
+    "checks": [
+      {
+        "checker": "c150_rg_count_match",
+        "status": "INVALID",
+        "message": "'read_group_count' not populated with an integer or value not greater than 0 in the metadata JSON"
+      },
+      {
+        "checker": "c230_files_info_data_category",
+        "status": "INVALID",
+        "message": "All files in the 'files' section of the metadata JSON are required to have 'info.data_category' field being populated with 'Sequencing Reads'. File(s) found not conforming to this requirement: 'test_rg_5.bam'."
+      },
+      {
+        "checker": "c240_submitter_rg_id_collide_with_rg_id_in_bam",
+        "status": "INVALID",
+        "message": "For any read group, when 'read_group_id_in_bam' is not populated, 'submitter_read_group_id' must NOT be the same as 'read_group_id_in_bam' of another read group from the same BAM file. However, offending submitter_read_group_id(s) found: D0RE2_1a_1"
+      },
+      {
+        "checker": "c250_file_data_type",
+        "status": "INVALID",
+        "message": "All files in the 'files' section of the metadata JSON are required to have 'dataType' field being populated with 'Submitted Reads'. File(s) found not conforming to this requirement: 'test_rg_5.bam'."
+      },
+      {
+        "checker": "c605_all_files_accessible",
+        "status": "INVALID",
+        "message": "Files specified in metadata, but missed in data directory: 'test_rg_5.cram'"
+      },
+      {
+        "checker": "c610_rg_id_in_bam",
+        "status": "INVALID",
+        "message": "No read group ID found in header for BAM: test_rg_5.bam"
+      },
+      {
+        "checker": "c620_submitter_read_group_id_match",
+        "status": "INVALID",
+        "message": "For each read group, when 'read_group_id_in_bam' is not provided, 'submitter_read_group_id' in the metadata JSON must match RG ID in the BAM file. Offending submitter_read_group_id(s): BAM test_rg_5.bam: D0RE2_1a_1"
+      },
+      {
+        "checker": "c630_rg_id_in_bam_match",
+        "status": "INVALID",
+        "message": "'read_group_id_in_bam' specified in 'read_groups' section of the metadata not found in BAM file. Offending ID(s): BAM test_rg_5.bam: D0RE2_1', D0RE2_1a_1"
+      },
+      {
+        "checker": "c640_one_sm_in_bam_header",
+        "status": "INVALID",
+        "message": "No SM found in @RG BAM header, BAM(s): test_rg_5.bam"
+      }
+    ]
+  }
+}

--- a/tests/submissions/anon_chr1_cram/anon_chr1_cram.missing.json
+++ b/tests/submissions/anon_chr1_cram/anon_chr1_cram.missing.json
@@ -1,0 +1,88 @@
+{
+  "analysisType": {
+    "name": "sequencing_experiment"
+  },
+  "studyId": "TEST-PR",
+  "experiment": {
+    "submitter_sequencing_experiment_id": "TEST_EXP",
+    "sequencing_center": "EXT",
+    "platform": "ILLUMINA",
+    "platform_model": "HiSeq 2000",
+    "experimental_strategy": "WGS",
+    "sequencing_date": "2014-12-12"
+  },
+  "read_group_count": 0,
+  "read_groups": [
+    {
+      "submitter_read_group_id": "D0RE2_1a_1",
+      "read_group_id_in_bam": null,
+      "platform_unit": "74_8a",
+      "is_paired_end": true,
+      "file_r1": "test_rg_5.bam",
+      "file_r2": "test_rg_5.bam",
+      "read_length_r1": 150,
+      "read_length_r2": 150,
+      "insert_size": 298,
+      "sample_barcode": null,
+      "library_name": "Pond-147580"
+    },
+    {
+      "submitter_read_group_id": "D0RE2_1a",
+      "read_group_id_in_bam": "D0RE2_1'",
+      "platform_unit": "74_8b",
+      "is_paired_end": true,
+      "file_r1": "test_rg_5.bam",
+      "file_r2": "test_rg_5.bam",
+      "read_length_r1": 150,
+      "read_length_r2": 150,
+      "insert_size": 298,
+      "sample_barcode": null,
+      "library_name": "Pond-147580"
+    },
+    {
+      "submitter_read_group_id": "D0RH0_2b",
+      "read_group_id_in_bam": "D0RE2_1a_1",
+      "platform_unit": "74_8c",
+      "is_paired_end": true,
+      "file_r1": "test_rg_5.bam",
+      "file_r2": "test_rg_5.bam",
+      "read_length_r1": 150,
+      "read_length_r2": 150,
+      "insert_size": 298,
+      "sample_barcode": null,
+      "library_name": "Pond-147580"
+    }
+  ],
+  "samples": [
+    {
+      "submitterSampleId": "HCC1143T",
+      "matchedNormalSubmitterSampleId": "HCC1143N",
+      "sampleType": "Total DNA",
+      "specimen": {
+        "submitterSpecimenId": "HCC1143T",
+        "tumourNormalDesignation": "Tumour",
+        "specimenTissueSource": "Blood derived",
+        "specimenType": "Tumour"
+      },
+      "donor": {
+        "submitterDonorId": "HCC1143",
+        "gender": "Female"
+      }
+    }
+  ],
+  "files": [
+    {
+      "fileName": "test_rg_5.bam",
+      "fileSize": 14935,
+      "fileMd5sum": "3f160ccdb1eae97337b42018bf141f7c",
+      "fileType": "BAM",
+      "fileAccess": "controlled",
+      "dataType": "",
+      "info": {
+        "original_cram_info":{
+          "fileName": "test_rg_5.cram"
+        }
+      }
+    }
+  ]
+}

--- a/tests/submissions/anon_chr1_cram/test_rg_5.bam
+++ b/tests/submissions/anon_chr1_cram/test_rg_5.bam
@@ -1,0 +1,1 @@
+../../seq-data/test_rg_5.bam


### PR DESCRIPTION
- updated 605 to look within `info` `file` field of payload in the event of cram2bam
- added test case where `cram` file was not accessible but `bam` was